### PR TITLE
Tour de chauffe : Inversion des boutons de thème et de langue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
                 "dotenv": "^16.4.5",
                 "lucide-react": "^0.438.0",
                 "negotiator": "^0.6.3",
-                "next": "^14.2.8",
+                "next": "^14.2.24",
                 "next-auth": "^5.0.0-beta.20",
                 "next-themes": "^0.4.4",
                 "nodemailer": "^6.9.15",
@@ -400,6 +400,70 @@
                 "glob": "10.3.10"
             }
         },
+        "node_modules/@next/swc-darwin-arm64": {
+            "version": "14.2.24",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.24.tgz",
+            "integrity": "sha512-7Tdi13aojnAZGpapVU6meVSpNzgrFwZ8joDcNS8cJVNuP3zqqrLqeory9Xec5TJZR/stsGJdfwo8KeyloT3+rQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@next/swc-darwin-x64": {
+            "version": "14.2.24",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.24.tgz",
+            "integrity": "sha512-lXR2WQqUtu69l5JMdTwSvQUkdqAhEWOqJEYUQ21QczQsAlNOW2kWZCucA6b3EXmPbcvmHB1kSZDua/713d52xg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@next/swc-linux-arm64-gnu": {
+            "version": "14.2.24",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.24.tgz",
+            "integrity": "sha512-nxvJgWOpSNmzidYvvGDfXwxkijb6hL9+cjZx1PVG6urr2h2jUqBALkKjT7kpfurRWicK6hFOvarmaWsINT1hnA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@next/swc-linux-arm64-musl": {
+            "version": "14.2.24",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.24.tgz",
+            "integrity": "sha512-PaBgOPhqa4Abxa3y/P92F3kklNPsiFjcjldQGT7kFmiY5nuFn8ClBEoX8GIpqU1ODP2y8P6hio6vTomx2Vy0UQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
         "node_modules/@next/swc-linux-x64-gnu": {
             "version": "14.2.24",
             "cpu": [
@@ -409,6 +473,70 @@
             "optional": true,
             "os": [
                 "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@next/swc-linux-x64-musl": {
+            "version": "14.2.24",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.24.tgz",
+            "integrity": "sha512-df0FC9ptaYsd8nQCINCzFtDWtko8PNRTAU0/+d7hy47E0oC17tI54U/0NdGk7l/76jz1J377dvRjmt6IUdkpzQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@next/swc-win32-arm64-msvc": {
+            "version": "14.2.24",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.24.tgz",
+            "integrity": "sha512-ZEntbLjeYAJ286eAqbxpZHhDFYpYjArotQ+/TW9j7UROh0DUmX7wYDGtsTPpfCV8V+UoqHBPU7q9D4nDNH014Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@next/swc-win32-ia32-msvc": {
+            "version": "14.2.24",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.24.tgz",
+            "integrity": "sha512-9KuS+XUXM3T6v7leeWU0erpJ6NsFIwiTFD5nzNg8J5uo/DMIPvCp3L1Ao5HjbHX0gkWPB1VrKoo/Il4F0cGK2Q==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@next/swc-win32-x64-msvc": {
+            "version": "14.2.24",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.24.tgz",
+            "integrity": "sha512-cXcJ2+x0fXQ2CntaE00d7uUH+u1Bfp/E0HsNQH79YiLaZE5Rbm7dZzyAYccn3uICM7mw+DxoMqEfGXZtF4Fgaw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
             ],
             "engines": {
                 "node": ">= 10"
@@ -5350,6 +5478,8 @@
         },
         "node_modules/next": {
             "version": "14.2.24",
+            "resolved": "https://registry.npmjs.org/next/-/next-14.2.24.tgz",
+            "integrity": "sha512-En8VEexSJ0Py2FfVnRRh8gtERwDRaJGNvsvad47ShkC2Yi8AXQPXEA2vKoDJlGFSj5WE5SyF21zNi4M5gyi+SQ==",
             "license": "MIT",
             "dependencies": {
                 "@next/env": "14.2.24",
@@ -6065,6 +6195,8 @@
         },
         "node_modules/react": {
             "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+            "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0"
@@ -6075,6 +6207,8 @@
         },
         "node_modules/react-dom": {
             "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+            "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "dotenv": "^16.4.5",
         "lucide-react": "^0.438.0",
         "negotiator": "^0.6.3",
-        "next": "^14.2.8",
+        "next": "^14.2.24",
         "next-auth": "^5.0.0-beta.20",
         "next-themes": "^0.4.4",
         "nodemailer": "^6.9.15",

--- a/src/components/navigation/navbar/links/locale-switcher.tsx
+++ b/src/components/navigation/navbar/links/locale-switcher.tsx
@@ -51,7 +51,7 @@ export const LocaleSwitch = ({
                 <Link href={localedUrl} legacyBehavior passHref className="border-2 border-red-500 ">
                     <NavigationMenuLink>
                         <div className={mobile ? " hover:bg-muted w-screen flex  justify-center py-2" : ""}>
-                            {locale === "en" ? <GB title="English" className="h-6 w-6" /> : <FR title="Français" className="h-6 w-6" />}
+                            {locale === "en" ? <FR title="Français" className="h-6 w-6" /> : <GB title="English" className="h-6 w-6" />}
                         </div>
                     </NavigationMenuLink>
                 </Link>

--- a/src/components/themes.tsx
+++ b/src/components/themes.tsx
@@ -26,8 +26,8 @@ export function ThemeSwitch({ onClick, setOpened }: { onClick: () => void; setOp
                 onClick();
             }}
         >
-            <IoSunny className="dark:hidden" />
-            <IoMoon className="dark:block hidden" />
+            <IoSunny className="dark:block hidden" />
+            <IoMoon className="dark:hidden" />
             <span className="sr-only">Toggle theme</span>
         </Button>
     );


### PR DESCRIPTION
L'idée était que les boutons proposent le thème et la langue plutôt qu'ils n'affichent l'état dans lequel on se trouve. C'est totalement arbitraire comme choix, le site de shadcn a fait ce choix par exemple tandis que les sites associés à Mistral ont fait le choix inverse.