### PR TITLE
fix(auth): Moved inline form actions with "use server" to separate files

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@formatjs/intl-localematcher": "^0.5.4",
         "@hookform/resolvers": "^3.9.0",
         "@number-flow/react": "^0.5.7",
-        "@prisma/client": "^6.1.0",
+        "@prisma/client": "^6.8.2",
         "@radix-ui/react-accordion": "^1.2.0",
         "@radix-ui/react-alert-dialog": "^1.1.1",
         "@radix-ui/react-checkbox": "^1.1.1",
@@ -52,12 +52,13 @@
         "@types/nodemailer": "^6.4.15",
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
+        "dotenv": "^16.5.0",
         "eslint": "^9.26.0",
         "eslint-config-next": "^15.3.2",
         "knip": "^5.56.0",
         "postcss": "^8.5.3",
         "postcss-load-config": "^6.0.1",
-        "prisma": "^6.1.0",
+        "prisma": "^6.8.2",
         "tailwindcss": "^3.4.10",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3",
@@ -259,19 +260,19 @@
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
-    "@prisma/client": ["@prisma/client@6.8.0", "", { "peerDependencies": { "prisma": "*", "typescript": ">=5.1.0" }, "optionalPeers": ["prisma", "typescript"] }, "sha512-t29bmo2VUOBIlinu0tRHXhj3r8+IwA7azetNOGqK9sQDVq/zwbSWq075P2kDjLhxpIe0L/g06bI22c307Tt4vA=="],
+    "@prisma/client": ["@prisma/client@6.8.2", "", { "peerDependencies": { "prisma": "*", "typescript": ">=5.1.0" }, "optionalPeers": ["prisma", "typescript"] }, "sha512-5II+vbyzv4si6Yunwgkj0qT/iY0zyspttoDrL3R4BYgLdp42/d2C8xdi9vqkrYtKt9H32oFIukvyw3Koz5JoDg=="],
 
-    "@prisma/config": ["@prisma/config@6.8.0", "", { "dependencies": { "jiti": "2.4.2" } }, "sha512-Bl1SCz6XGa7InatzFBLpY2Ni3anJhPbDHz5RPmmdjaVVnK9Fo1oA4T1FInKLsabn0qjQE6iwCUe6OMu5Up1iGw=="],
+    "@prisma/config": ["@prisma/config@6.8.2", "", { "dependencies": { "jiti": "2.4.2" } }, "sha512-ZJY1fF4qRBPdLQ/60wxNtX+eu89c3AkYEcP7L3jkp0IPXCNphCYxikTg55kPJLDOG6P0X+QG5tCv6CmsBRZWFQ=="],
 
-    "@prisma/debug": ["@prisma/debug@6.8.0", "", {}, "sha512-QgI80ZgD5xWI+DzNOw2LkZQpE2ZBV9NiTkPqcOTAWe3+sLagGGau4Sp18lrYsemEqzfYD6Zl1YJkCO4JFmywLg=="],
+    "@prisma/debug": ["@prisma/debug@6.8.2", "", {}, "sha512-4muBSSUwJJ9BYth5N8tqts8JtiLT8QI/RSAzEogwEfpbYGFo9mYsInsVo8dqXdPO2+Rm5OG5q0qWDDE3nyUbVg=="],
 
-    "@prisma/engines": ["@prisma/engines@6.8.0", "", { "dependencies": { "@prisma/debug": "6.8.0", "@prisma/engines-version": "6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e", "@prisma/fetch-engine": "6.8.0", "@prisma/get-platform": "6.8.0" } }, "sha512-F1L6EbM4QsC84KzNk2gBiulmWvj4QRe+9QqHIAgKMPSOPnJhjeNSdcOrc2qkctJxew8F18tyzZOrcgHVg76IxQ=="],
+    "@prisma/engines": ["@prisma/engines@6.8.2", "", { "dependencies": { "@prisma/debug": "6.8.2", "@prisma/engines-version": "6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e", "@prisma/fetch-engine": "6.8.2", "@prisma/get-platform": "6.8.2" } }, "sha512-XqAJ//LXjqYRQ1RRabs79KOY4+v6gZOGzbcwDQl0D6n9WBKjV7qdrbd042CwSK0v0lM9MSHsbcFnU2Yn7z8Zlw=="],
 
     "@prisma/engines-version": ["@prisma/engines-version@6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e", "", {}, "sha512-Rkik9lMyHpFNGaLpPF3H5q5TQTkm/aE7DsGM5m92FZTvWQsvmi6Va8On3pWvqLHOt5aPUvFb/FeZTmphI4CPiQ=="],
 
-    "@prisma/fetch-engine": ["@prisma/fetch-engine@6.8.0", "", { "dependencies": { "@prisma/debug": "6.8.0", "@prisma/engines-version": "6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e", "@prisma/get-platform": "6.8.0" } }, "sha512-3mXaUxyqA2IHWGw4uHsA7yXyN2F6KVJ8Re7JgUwsHsYS4rgXXC7N4YIFfuStFw2y937RHgJfxzYBt2djkIbZXw=="],
+    "@prisma/fetch-engine": ["@prisma/fetch-engine@6.8.2", "", { "dependencies": { "@prisma/debug": "6.8.2", "@prisma/engines-version": "6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e", "@prisma/get-platform": "6.8.2" } }, "sha512-lCvikWOgaLOfqXGacEKSNeenvj0n3qR5QvZUOmPE2e1Eh8cMYSobxonCg9rqM6FSdTfbpqp9xwhSAOYfNqSW0g=="],
 
-    "@prisma/get-platform": ["@prisma/get-platform@6.8.0", "", { "dependencies": { "@prisma/debug": "6.8.0" } }, "sha512-NyHPoTGOZt/pDSWh0ioSU8EylBpEKdrCpgh5kfIqLww/HGMfgdmCPVMf+qBtSJXthqUIS6qAZ04Bvwq1qJHEdg=="],
+    "@prisma/get-platform": ["@prisma/get-platform@6.8.2", "", { "dependencies": { "@prisma/debug": "6.8.2" } }, "sha512-vXSxyUgX3vm1Q70QwzwkjeYfRryIvKno1SXbIqwSptKwqKzskINnDUcx85oX+ys6ooN2ATGSD0xN2UTfg6Zcow=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
@@ -628,6 +629,8 @@
     "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
+
+    "dotenv": ["dotenv@16.5.0", "", {}, "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -1167,7 +1170,7 @@
 
     "prettier": ["prettier@3.5.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw=="],
 
-    "prisma": ["prisma@6.8.0", "", { "dependencies": { "@prisma/config": "6.8.0", "@prisma/engines": "6.8.0" }, "peerDependencies": { "typescript": ">=5.1.0" }, "optionalPeers": ["typescript"], "bin": { "prisma": "build/index.js" } }, "sha512-Jv1DrZs4DhL4b0URa0cMtY4VRYrlGTbTAPjEITvYG7KjfC0yUPXxH8ZvPnLj0jolbJnR7aMqA1Ait9J1KG2GCA=="],
+    "prisma": ["prisma@6.8.2", "", { "dependencies": { "@prisma/config": "6.8.2", "@prisma/engines": "6.8.2" }, "peerDependencies": { "typescript": ">=5.1.0" }, "optionalPeers": ["typescript"], "bin": { "prisma": "build/index.js" } }, "sha512-JNricTXQxzDtRS7lCGGOB4g5DJ91eg3nozdubXze3LpcMl1oWwcFddrj++Up3jnRE6X/3gB/xz3V+ecBk/eEGA=="],
 
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -60,7 +60,6 @@
         "postcss-load-config": "^6.0.1",
         "prisma": "^6.8.2",
         "tailwindcss": "^3.4.10",
-        "ts-node": "^10.9.2",
         "typescript": "^5.8.3",
       },
     },
@@ -166,7 +165,7 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
 
-    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.11.3", "", { "dependencies": { "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-rmOWVRUbUJD7iSvJugjUbFZshTAuJ48MXoZ80Osx1GM0K/H1w7rSEvmw8m6vdWxNASgtaHIhAgre4H/E9GJiYQ=="],
 
@@ -1448,13 +1447,13 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@eslint/eslintrc/strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
-
-    "@jridgewell/gen-mapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
 
     "@next/eslint-plugin-next/fast-glob": ["fast-glob@3.3.1", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.4" } }, "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg=="],
 

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -8,6 +8,7 @@ const config: KnipConfig = {
         '.github/workflows/*.yml',
     ],
     ignoreDependencies: ['eslint-config-next'],
+    ignoreBinaries: ['tsx'],
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "prisma": {
-        "seed": "ts-node prisma/seed.ts"
+        "seed": "tsx prisma/seed.ts"
     },
     "scripts": {
         "dev": "next dev",
@@ -17,7 +17,7 @@
         "@formatjs/intl-localematcher": "^0.5.4",
         "@hookform/resolvers": "^3.9.0",
         "@number-flow/react": "^0.5.7",
-        "@prisma/client": "^6.1.0",
+        "@prisma/client": "^6.8.2",
         "@radix-ui/react-accordion": "^1.2.0",
         "@radix-ui/react-alert-dialog": "^1.1.1",
         "@radix-ui/react-checkbox": "^1.1.1",
@@ -61,12 +61,13 @@
         "@types/nodemailer": "^6.4.15",
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
+        "dotenv": "^16.5.0",
         "eslint": "^9.26.0",
         "eslint-config-next": "^15.3.2",
         "knip": "^5.56.0",
         "postcss": "^8.5.3",
         "postcss-load-config": "^6.0.1",
-        "prisma": "^6.1.0",
+        "prisma": "^6.8.2",
         "tailwindcss": "^3.4.10",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
         "postcss-load-config": "^6.0.1",
         "prisma": "^6.8.2",
         "tailwindcss": "^3.4.10",
-        "ts-node": "^10.9.2",
         "typescript": "^5.8.3"
     }
 }

--- a/src/app/[locale]/(static)/auth/signin/page.tsx
+++ b/src/app/[locale]/(static)/auth/signin/page.tsx
@@ -4,12 +4,13 @@ import Image from 'next/image';
 
 import Google from '@/../public/icons/google.svg';
 
-import { signIn } from '@/auth/auth';
 import { EmailContact } from '@/components/telecom-etude/contact';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { LocaleParams } from '@/locales/config';
 import { getDictionary } from '@/locales/dictionaries';
+
+import { googleSignin } from './signin';
 
 export default async function SignIn({ params }: LocaleParams) {
     const { locale } = await params;
@@ -22,12 +23,7 @@ export default async function SignIn({ params }: LocaleParams) {
                         <CardTitle className="w-full text-center pb-2">{t.title}</CardTitle>
                     </CardHeader>
                     <CardContent className="p-6">
-                        <form
-                            action={async () => {
-                                'use server';
-                                await signIn('google');
-                            }}
-                        >
+                        <form action={googleSignin}>
                             <Button
                                 type="submit"
                                 variant="link"

--- a/src/app/[locale]/(static)/auth/signin/signin.ts
+++ b/src/app/[locale]/(static)/auth/signin/signin.ts
@@ -3,6 +3,5 @@
 import { signIn } from '@/auth/auth';
 
 export async function googleSignin() {
-    'use server';
     await signIn('google');
 }

--- a/src/app/[locale]/(static)/auth/signin/signin.ts
+++ b/src/app/[locale]/(static)/auth/signin/signin.ts
@@ -1,0 +1,8 @@
+'use server';
+
+import { signIn } from '@/auth/auth';
+
+export async function googleSignin() {
+    'use server';
+    await signIn('google');
+}

--- a/src/app/[locale]/(static)/auth/signout/page.tsx
+++ b/src/app/[locale]/(static)/auth/signout/page.tsx
@@ -1,11 +1,12 @@
 'use server';
 
-import { signOut } from '@/auth/auth';
 import { EmailContact } from '@/components/telecom-etude/contact';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { LocaleParams } from '@/locales/config';
 import { getDictionary } from '@/locales/dictionaries';
+
+import { googleSignout } from './signout';
 
 export default async function SignIn({ params }: LocaleParams) {
     const { locale } = await params;
@@ -18,12 +19,7 @@ export default async function SignIn({ params }: LocaleParams) {
                         <CardTitle className="w-full text-center pb-2">{t.title}</CardTitle>
                     </CardHeader>
                     <CardContent className="p-6">
-                        <form
-                            action={async () => {
-                                'use server';
-                                await signOut();
-                            }}
-                        >
+                        <form action={googleSignout}>
                             <Button
                                 type="submit"
                                 variant="link"

--- a/src/app/[locale]/(static)/auth/signout/signout.ts
+++ b/src/app/[locale]/(static)/auth/signout/signout.ts
@@ -1,0 +1,6 @@
+import { signOut } from '@/auth/auth';
+
+export async function googleSignout() {
+    'use server';
+    await signOut();
+}

--- a/src/app/[locale]/(static)/auth/signout/signout.ts
+++ b/src/app/[locale]/(static)/auth/signout/signout.ts
@@ -1,6 +1,7 @@
+'use server';
+
 import { signOut } from '@/auth/auth';
 
 export async function googleSignout() {
-    'use server';
     await signOut();
 }


### PR DESCRIPTION
Inline form actions which use "use server" were broken and caused an error 500. So I moved them into separate files (src/app/[locale]/(static)/auth/signout/signout.ts and src/app/[locale]/(static)/auth/signin/signin.ts).

Also, the dotenv dependancy was missing, and was causing problems with prisma seeding. I added that in dev dependancies.