### PR TITLE
fix(legal): changed site host contact email to rezel

### DIFF
--- a/src/app/[locale]/(static)/(client)/legal/page.tsx
+++ b/src/app/[locale]/(static)/(client)/legal/page.tsx
@@ -44,7 +44,7 @@ export default async function Legal({ params }: LocaleParams) {
                         <h3 className="font-semibold">{t.legal.host.title}</h3>
                         <p>{t.legal.host.description}</p>
                         <p>
-                            {t.legal.host.contact} <EmailContact />
+                            {t.legal.host.contact} <EmailContact rezel />
                         </p>
                         <p>
                             {t.legal.host.website}{' '}

--- a/src/components/telecom-etude/contact.tsx
+++ b/src/components/telecom-etude/contact.tsx
@@ -22,11 +22,13 @@ export const EmailBtn = ({
 export const EmailContact = ({
     rgpd = false,
     dsi = false,
+    rezel = false,
     text,
     underline = false,
 }: {
     rgpd?: boolean;
     dsi?: boolean;
+    rezel?: boolean;
     text?: string;
     underline?: boolean;
 }) => {
@@ -38,7 +40,9 @@ export const EmailContact = ({
                     ? 'secretaire.general@telecom-etude.fr'
                     : dsi
                       ? 'info.telecom-paris.fr'
-                      : 'contact@telecom-etude.fr'
+                      : rezel
+                        ? 'contact@rezel.net'
+                        : 'contact@telecom-etude.fr'
             }
             text={text}
         />


### PR DESCRIPTION
The contact email for the website host was set to TE's contact, but it needed to be rezel's
