### PR TITLE
fix(home): made description text visible on mobile

### DIFF
--- a/src/app/[locale]/(static)/(client)/(home)/page.tsx
+++ b/src/app/[locale]/(static)/(client)/(home)/page.tsx
@@ -128,7 +128,9 @@ function Description({
 }) {
     return (
         <>
-            <p className={cn('text-center text-white', className)}>{t.description}</p>
+            <p className={cn('text-center text-foreground lg:text-white', className)}>
+                {t.description}
+            </p>
             <div
                 className={cn(
                     'flex flex-col sm:flex-row space-y-10 sm:space-x-10 sm:space-y-0 justify-center',


### PR DESCRIPTION
The description text on the homepage was invisible in light mode because there was white text on a white background. I made the text adapt its color depending on the screen size so that it's visible in any case.
